### PR TITLE
fix: move imports before constants

### DIFF
--- a/src/components/Certs.jsx
+++ b/src/components/Certs.jsx
@@ -1,9 +1,8 @@
 import React from 'react'
+import Courses from "./Courses";
 
 const HCIA = 'https://via.placeholder.com/150'
 const GCC = 'https://via.placeholder.com/150'
-
-import Courses from "./Courses";
 
 const Certs = () => {
   const certifications = [

--- a/src/components/Courses.jsx
+++ b/src/components/Courses.jsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react'
+import Modal from './subcomponents/imagemodal'
+
 const C2 = 'https://via.placeholder.com/300'
 const C3 = 'https://via.placeholder.com/300'
 const C4 = 'https://via.placeholder.com/300'
@@ -7,8 +9,6 @@ const C6 = 'https://via.placeholder.com/300'
 const C7 = 'https://via.placeholder.com/300'
 const C8 = 'https://via.placeholder.com/300'
 const C9 = 'https://via.placeholder.com/300'
-
-import Modal from './subcomponents/imagemodal'
 const Courses = () => {
   const certifications = [
     {

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -2,9 +2,10 @@ import React from 'react'
 import { motion } from 'framer-motion'
 import { Github, Linkedin, Mail, FileText } from 'lucide-react'
 import { TypeAnimation } from 'react-type-animation'
+import { InteractiveHoverButton } from '../components/subcomponents/interactive-hover-button'
+
 const heroimage = 'https://via.placeholder.com/400'
 const resume = 'https://example.com/resume.pdf'
-import { InteractiveHoverButton } from '../components/subcomponents/interactive-hover-button'
 
 export default function Hero({ onWantToKnowMoreClick }) {
   const gotoSection = (event, id) => {

--- a/src/components/data/projects.js
+++ b/src/components/data/projects.js
@@ -1,10 +1,3 @@
-//Display Images
-const KodyAdventureImage = 'https://via.placeholder.com/300';
-const TradeHistoryImage = 'https://via.placeholder.com/300';
-const Linux = 'https://via.placeholder.com/300';
-const vul = 'https://via.placeholder.com/300';
-const Sql = 'https://via.placeholder.com/300';
-
 //Project Components
 import AppProject1 from '../../components/subcomponents/AppProject1'
 import AppProject2 from '../../components/subcomponents/AppProject2'
@@ -12,6 +5,13 @@ import Project1 from '../../components/subcomponents/Project1'
 import Project2 from '../../components/subcomponents/Project2'
 import Project3 from '../../components/subcomponents/Project3'
 import Project4 from '../../components/subcomponents/Project4'
+
+//Display Images
+const KodyAdventureImage = 'https://via.placeholder.com/300';
+const TradeHistoryImage = 'https://via.placeholder.com/300';
+const Linux = 'https://via.placeholder.com/300';
+const vul = 'https://via.placeholder.com/300';
+const Sql = 'https://via.placeholder.com/300';
 
 
 

--- a/src/components/subcomponents/AppProject1.jsx
+++ b/src/components/subcomponents/AppProject1.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
-const TradeHistoryImage = 'https://via.placeholder.com/600x400'
 import { projectStyles as styles } from './ProjectStyles'
+const TradeHistoryImage = 'https://via.placeholder.com/600x400'
 
 const AppProject1 = () => {
   const technologies = ["Java", "XML", "Android Studio", "SQLite"];


### PR DESCRIPTION
## Summary
- move imports above constants in Certs and Courses components
- place Hero and AppProject1 imports before file-level constants
- reorganize projects data imports to precede constant declarations

## Testing
- `npx eslint src/components/Certs.jsx src/components/Courses.jsx src/components/Hero.jsx src/components/data/projects.js src/components/subcomponents/AppProject1.jsx && echo "Lint passed"`
- `timeout 60s npm start >/tmp/start.log 2>&1`

------
https://chatgpt.com/codex/tasks/task_e_68a1e8072e14833197f721d4d6044ad2